### PR TITLE
Fix E565 textlock error in Neovim 0.12+

### DIFF
--- a/lua/neopyter/jupyter/notebook.lua
+++ b/lua/neopyter/jupyter/notebook.lua
@@ -76,19 +76,21 @@ function Notebook:attach()
         })
         api.nvim_buf_attach(self.bufnr, false, {
             on_lines = function(_, _, _, start_row, old_end_row, new_end_row, _)
-                a.run(function()
-                    local syncable = self:safe_sync()
-                    if syncable then
-                        if config.jupyter.partial_sync then
-                            self:partial_sync(start_row, old_end_row - 1, new_end_row - 1)
+                vim.schedule(function()
+                    a.run(function()
+                        local syncable = self:safe_sync()
+                        if syncable then
+                            if config.jupyter.partial_sync then
+                                self:partial_sync(start_row, old_end_row - 1, new_end_row - 1)
+                            else
+                                self:parse()
+                                self:full_sync()
+                            end
                         else
                             self:parse()
-                            self:full_sync()
                         end
-                    else
-                        self:parse()
-                    end
-                end, function() end)
+                    end, function() end)
+                end)
             end,
         })
     end


### PR DESCRIPTION
# Fix E565 textlock error in Neovim 0.12+

## Problem

On Neovim 0.12+, editing buffer content triggers the following error:

```
Error: Lua callback: ...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:18:
The coroutine failed with this message:
...y/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:147:
E565: Not allowed to change text or change window
```

## Root Cause

Neovim 0.12+ enforces stricter **textlock** restrictions. The textlock mechanism prevents buffer modifications and window operations during certain callbacks to maintain consistency.

The issue occurs in `lua/neopyter/jupyter/notebook.lua:77-93`:

```lua
api.nvim_buf_attach(self.bufnr, false, {
    on_lines = function(_, _, _, start_row, old_end_row, new_end_row, _)
        a.run(function()
            -- ...
            self:parse()  -- Calls treesitter API
            -- ...
        end, function() end)
    end,
})
```

When `on_lines` callback is invoked:
1. The callback runs under **textlock** (buffer modification lock)
2. `self:parse()` calls `nvim_buf_get_lines` and treesitter's `parse_notebook`
3. Treesitter operations attempt to access/modify the syntax tree
4. Neovim 0.12+ stricter textlock enforcement throws E565 error

## Solution

Wrap the async operation with `vim.schedule()` to defer execution until after textlock is released:

```lua
api.nvim_buf_attach(self.bufnr, false, {
    on_lines = function(_, _, _, start_row, old_end_row, new_end_row, _)
        vim.schedule(function()  -- Defer to next event loop tick
            a.run(function()
                -- Safe to call treesitter and buffer operations here
                -- ...
            end, function() end)
        end)
    end,
})
```

## Changes

- **File**: `lua/neopyter/jupyter/notebook.lua`
- **Line**: 79 (added `vim.schedule` wrapper)
- **Impact**: Minimal - operations are deferred by one event loop tick (imperceptible to users)

