### PR TITLE
ci: use conventional commit message for docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Commit and Push Documentation
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "auto-generate document"
+          commit_message: "docs: auto-generate documentation"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Summary
- update the docs workflow auto-generated commit message to follow Conventional Commits
- keep the existing bot author configuration unchanged